### PR TITLE
Fix: gradually refresh CV preview.

### DIFF
--- a/frontend/src/components/pdf/PDFViewer/PDFViewer.js
+++ b/frontend/src/components/pdf/PDFViewer/PDFViewer.js
@@ -42,7 +42,7 @@ export class PDFViewer extends React.Component {
         type:
           'application/pdf'
       }))
-      if (!this.props.previousBlob) {
+      if (!this.props.pdfViewer.previousBlob) {
         this.props.updatePreviousBlob(url)
       }
       setTimeout(() => {


### PR DESCRIPTION
There are a few Redux reducers in the system. Prior to #1, a PDFViewer UI component has only used one of them. Now that it needs to generate text CV to be downloaded, I needed to give it access to all the reducers. One reference was wrong.

Was:
```
this.props.previousBlob
```

Should be:
```
this.props.pdfViewer.previousBlob
```

Now it's fixed.