### PR TITLE
Fix navigation for CV preview

### DIFF
--- a/frontend/src/components/pdf/PDFViewer/PDFViewer.js
+++ b/frontend/src/components/pdf/PDFViewer/PDFViewer.js
@@ -293,17 +293,22 @@ ${this.props.gdpa.gdpa}
 
       <div className="pdf" style={styles.pdf}>
         <Button
+        iconCategory="utility"
+        iconName="chevronleft"
+        iconPosition="left"
+        disabled={!this.state.isPreviousPage}
+          
           onClick={this.setIsPreviousPage}
-          className={`${this.state.isPreviousPage ? 'enabled' : 'disabled'}`}
-        >
-          previous page
-        </Button>
+          label="Previous page"
+        />
         <Button
+        iconCategory="utility"
+        iconName="chevronright"
+        iconPosition="right"
           onClick={this.setIsNextPage}
-          className={`${this.state.isNextPage ? 'enabled' : 'disabled'}`}
-        >
-          next page
-        </Button>
+          disabled={!this.state.isNextPage}
+          label="Next page"
+        />
 
 
         <Dropdown


### PR DESCRIPTION
Due to changing component system, CV preview navigation didn't work as intended. Now buttons are disabled when there are no next or previous pages.